### PR TITLE
fix k=7 bug in make_powk fn

### DIFF
--- a/src/HF/CoulombIntegrals.cpp
+++ b/src/HF/CoulombIntegrals.cpp
@@ -438,7 +438,7 @@ static inline std::function<double(double)> make_powk(const int k) {
     return [](double x) { return x * x * x * x * x; };
   if (k == 6)
     return [](double x) { return x * x * x * x * x * x; };
-  if (k == 6)
+  if (k == 7)
     return [](double x) { return x * x * x * x * x * x * x; };
   return [=](double x) { return std::pow(x, k); };
 }


### PR DESCRIPTION
Fix typo in make_powk() fn in CoulombIntegrals.cpp